### PR TITLE
v1.7.2.2

### DIFF
--- a/QuestMap/Commands.cs
+++ b/QuestMap/Commands.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using Dalamud.Game.Command;
+using Lumina.Excel.Sheets;
 
 namespace QuestMap {
     internal class Commands : IDisposable {
@@ -8,9 +10,7 @@ namespace QuestMap {
         internal Commands(Plugin plugin) {
             this.Plugin = plugin;
 
-            this.Plugin.CommandManager.AddHandler("/quests", new CommandInfo(this.OnCommand) {
-                HelpMessage = "Show Quest Map",
-            });
+            this.Plugin.CommandManager.AddHandler("/quests", new CommandInfo(this.OnCommand) { HelpMessage = "Show Quest Map" });
         }
 
         public void Dispose() {
@@ -18,7 +18,22 @@ namespace QuestMap {
         }
 
         private void OnCommand(string command, string args) {
-            this.Plugin.Ui.Show ^= true;
+            if (string.IsNullOrWhiteSpace(args))
+            {
+                this.Plugin.Ui.Show ^= true;
+            }
+            else
+            {
+                if (uint.TryParse(args, out var questId))
+                {
+                    this.Plugin.Ui.ShowQuest(questId);
+                }
+                else
+                {
+                    var node = this.Plugin.Quests.AllNodes.Values.FirstOrDefault(node => node.Name.Equals(args, StringComparison.InvariantCultureIgnoreCase));
+                    if (node is not null) this.Plugin.Ui.ShowQuest(node.Quest);
+                }
+            }
         }
     }
 }

--- a/QuestMap/Commands.cs
+++ b/QuestMap/Commands.cs
@@ -10,14 +10,15 @@ namespace QuestMap {
         internal Commands(Plugin plugin) {
             this.Plugin = plugin;
 
-            this.Plugin.CommandManager.AddHandler("/quests", new CommandInfo(this.OnCommand) { HelpMessage = "Show Quest Map" });
+            this.Plugin.CommandManager.AddHandler("/quests", new CommandInfo(this.ShowGraphCommand) { HelpMessage = "Show Quest Map" });
+            this.Plugin.CommandManager.AddHandler("/questinfo", new CommandInfo(this.ShowInfoCommand) { HelpMessage = "Show information for a specified quest by name or id" });
         }
 
         public void Dispose() {
             this.Plugin.CommandManager.RemoveHandler("/quests");
         }
 
-        private void OnCommand(string command, string args) {
+        private void ShowGraphCommand(string command, string args) {
             if (string.IsNullOrWhiteSpace(args))
             {
                 this.Plugin.Ui.Show ^= true;
@@ -32,6 +33,26 @@ namespace QuestMap {
                 {
                     var node = this.Plugin.Quests.AllNodes.Values.FirstOrDefault(node => node.Name.Equals(args, StringComparison.InvariantCultureIgnoreCase));
                     if (node is not null) this.Plugin.Ui.ShowQuest(node.Quest);
+                }
+            }
+        }
+
+        private void ShowInfoCommand(string command, string args)
+        {
+            if (string.IsNullOrWhiteSpace(args))
+            {
+                this.Plugin.Chat.PrintError("/questinfo needs a quest name or id");
+            }
+            else
+            {
+                if (uint.TryParse(args, out var questId))
+                {
+                    this.Plugin.Ui.ShowInfo(questId);
+                }
+                else
+                {
+                    var node = this.Plugin.Quests.AllNodes.Values.FirstOrDefault(node => node.Name.Equals(args, StringComparison.InvariantCultureIgnoreCase));
+                    if (node is not null) this.Plugin.Ui.ShowInfo(node.Quest);
                 }
             }
         }

--- a/QuestMap/Ipc.cs
+++ b/QuestMap/Ipc.cs
@@ -6,6 +6,7 @@ namespace QuestMap
     internal sealed class Ipc : IDisposable
     {
         private readonly ICallGateProvider<uint, bool> _showGraphByQuestIdIpc;
+        private readonly ICallGateProvider<uint, bool> _showInfoByQuestIdIpc;
 
         private Plugin Plugin { get; }
 
@@ -15,13 +16,18 @@ namespace QuestMap
 
             this._showGraphByQuestIdIpc = this.Plugin.Interface.GetIpcProvider<uint, bool>("QuestMap.ShowGraphByQuestId");
             this._showGraphByQuestIdIpc.RegisterFunc(this.ShowGraphByQuestId);
+
+            this._showInfoByQuestIdIpc = this.Plugin.Interface.GetIpcProvider<uint, bool>("QuestMap.ShowInfoByQuestId");
+            this._showInfoByQuestIdIpc.RegisterFunc(this.ShowInfoByQuestId);
         }
 
         private bool ShowGraphByQuestId(uint questId) => this.Plugin.Ui.ShowQuest(questId);
+        private bool ShowInfoByQuestId(uint questId) => this.Plugin.Ui.ShowInfo(questId);
 
         public void Dispose()
         {
             this._showGraphByQuestIdIpc.UnregisterFunc();
+            this._showInfoByQuestIdIpc.UnregisterFunc();
         }
     }
 }

--- a/QuestMap/Ipc.cs
+++ b/QuestMap/Ipc.cs
@@ -1,0 +1,27 @@
+﻿using Dalamud.Plugin.Ipc;
+using System;
+
+namespace QuestMap
+{
+    internal sealed class Ipc : IDisposable
+    {
+        private readonly ICallGateProvider<uint, bool> _showGraphByQuestIdIpc;
+
+        private Plugin Plugin { get; }
+
+        public Ipc(Plugin plugin)
+        {
+            this.Plugin = plugin;
+
+            this._showGraphByQuestIdIpc = this.Plugin.Interface.GetIpcProvider<uint, bool>("QuestMap.ShowGraphByQuestId");
+            this._showGraphByQuestIdIpc.RegisterFunc(this.ShowGraphByQuestId);
+        }
+
+        private bool ShowGraphByQuestId(uint questId) => this.Plugin.Ui.ShowQuest(questId);
+
+        public void Dispose()
+        {
+            this._showGraphByQuestIdIpc.UnregisterFunc();
+        }
+    }
+}

--- a/QuestMap/Plugin.cs
+++ b/QuestMap/Plugin.cs
@@ -18,6 +18,9 @@ namespace QuestMap {
         internal ICommandManager CommandManager { get; init; } = null!;
 
         [PluginService]
+        internal IChatGui Chat { get; init; } = default!;
+
+        [PluginService]
         internal IDataManager DataManager { get; init; } = null!;
 
         [PluginService]

--- a/QuestMap/Plugin.cs
+++ b/QuestMap/Plugin.cs
@@ -33,6 +33,7 @@ namespace QuestMap {
         internal Quests Quests { get; }
         internal PluginUi Ui { get; }
         private Commands Commands { get; }
+        private Ipc Ipc { get; }
 
         public Plugin(IDalamudPluginInterface pluginInterface) {
             pluginInterface.Inject(this);
@@ -42,9 +43,11 @@ namespace QuestMap {
             this.Ui = new PluginUi(this);
 
             this.Commands = new Commands(this);
+            this.Ipc = new Ipc(this);
         }
 
         public void Dispose() {
+            this.Ipc.Dispose();
             this.Commands.Dispose();
             this.Ui.Dispose();
         }

--- a/QuestMap/PluginUi.cs
+++ b/QuestMap/PluginUi.cs
@@ -389,6 +389,17 @@ namespace QuestMap {
             return false;
         }
 
+        public void ShowInfo(Quest quest) => this.InfoWindows.Add(quest.RowId);
+        public bool ShowInfo(uint questId)
+        {
+            if (this.Plugin.Quests.AllNodes.ContainsKey(questId))
+            {
+                this.InfoWindows.Add(questId);
+                return true;
+            }
+            return false;
+        }
+
         private void DrawInfoWindows() {
             var remove = 0u;
 

--- a/QuestMap/PluginUi.cs
+++ b/QuestMap/PluginUi.cs
@@ -662,6 +662,7 @@ namespace QuestMap {
             if (Util.IconButton(FontAwesomeIcon.ProjectDiagram)) {
                 this.Quest = quest;
                 this._relayout = true;
+                this.Show = true;
             }
 
             Util.Tooltip("Show quest graph");

--- a/QuestMap/PluginUi.cs
+++ b/QuestMap/PluginUi.cs
@@ -372,6 +372,23 @@ namespace QuestMap {
             ImGui.End();
         }
 
+        public void ShowQuest(Quest quest)
+        {
+            this.Quest = quest;
+            this.Show = true;
+            this._relayout = true;
+        }
+
+        public bool ShowQuest(uint questId)
+        {
+            if (this.Plugin.Quests.AllNodes.TryGetValue(questId, out var node))
+            {
+                this.ShowQuest(node.Quest);
+                return true;
+            }
+            return false;
+        }
+
         private void DrawInfoWindows() {
             var remove = 0u;
 

--- a/QuestMap/QuestMap.csproj
+++ b/QuestMap/QuestMap.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net9-windows</TargetFramework>
-        <Version>1.7.2.0</Version>
+        <Version>1.7.2.1</Version>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/QuestMap/QuestMap.csproj
+++ b/QuestMap/QuestMap.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net9-windows</TargetFramework>
-        <Version>1.7.2.1</Version>
+        <Version>1.7.2.2</Version>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ Explore quests and their rewards.
 - Open quest starting locations on the map or open quests in the journal.
 
 ## IPC
-- `bool QuestMap.ShowGraphByQuestId(uint questId)`: Shows the quest map with the specified quest id selected. Returns a bool indicating success.
+- `bool QuestMap.ShowGraphByQuestId(uint questId)`: Shows the quest map with the specified quest id selected.
   - **`questId`**: Quest ID to be shown on the quest map.
   - **Returns**: A boolean indicating success. Upon success (`true`) the quest map is shown to the user with the specified quest ID selected. Upon failure (`false`) nothing happens.
+
+- `bool QuestMap.ShowInfoByQuestId(uint questId)`: Shows the quest information for the specified quest id.
+  - **`questId`**: Quest ID of the quest information to be shown.
+  - **Returns**: A boolean indicating success. Upon success (`true`) the quest information is shown to the user for the specified quest ID. Upon failure (`false`) nothing happens.
 
 ## Credits
 ### Plugin

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# QuestMap
+Explore quests and their rewards.
+- Search for quest names or their rewards, including instances, beast tribes, minions, etc.
+- See an interactive map of quest requirements and unlocks.
+- Open a quest info window even for quests you haven't completed.
+- Open quest starting locations on the map or open quests in the journal.
+
+## IPC
+- `bool QuestMap.ShowGraphByQuestId(uint questId)`: Shows the quest map with the specified quest id selected. Returns a bool indicating success.
+  - **`questId`**: Quest ID to be shown on the quest map.
+  - **Returns**: A boolean indicating success. Upon success (`true`) the quest map is shown to the user with the specified quest ID selected. Upon failure (`false`) nothing happens.
+
+## Credits
+### Plugin
+- Anna for creating this plugin.
+- Azure Gem for continued maintenance.
+
+### Icons
+- Treasure Map by Anthony Ledoux from the Noun Project
+- Locked Book by Anthony Ledoux from the Noun Project


### PR DESCRIPTION
### Bugs
- Open map window when clicking Show quest graph if not already open. (Fixes #4)

### Commands
- `/quests` now optionally accepts a quest ID or name to be shown.
- `/questinfo` implemented, accepts a quest ID or name for the information window to be shown. (Implements #3)

### IPC
- New IPC Command: `QuestMap.ShowGraphByQuestId`.
- New IPC Command: `QuestMap.ShowInfoByQuestId`.

### Misc
- Readme added, which includes the documentation for the IPC commands.